### PR TITLE
updating deprecated ubuntu ami version

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -62,7 +62,7 @@ data "aws_ami" "ubuntu" {
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20220420"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20240514"]
   }
 
   filter {


### PR DESCRIPTION
![image](https://github.com/josephmachado/data_engineering_project_template/assets/89270394/136114fc-4b93-48ca-ad3f-800b0b7c5b4f)
The ubuntu version is deprecated, as a result, it returns the error shown in the picture when we run make infra-up. Changing the version to the one solves the issue.